### PR TITLE
Enable non-local file access on Windows

### DIFF
--- a/pbp/file_helper.py
+++ b/pbp/file_helper.py
@@ -99,8 +99,8 @@ class SoundStatus:
         else:
             sound_filename = path
 
-        if os.name == 'nt':
-            return self.parsed_uri.netloc+self.parsed_uri.path
+        if os.name == "nt":
+            return self.parsed_uri.netloc + self.parsed_uri.path
         else:
             return sound_filename
 
@@ -356,7 +356,7 @@ class FileHelper:
         if parsed_uri.scheme == "s3":
             return self._get_json_s3(parsed_uri)
         #  simply assume local file:
-        if os.name == 'nt':
+        if os.name == "nt":
             return self._get_json_local(uri)
         else:
             return self._get_json_local(parsed_uri.path)

--- a/pbp/file_helper.py
+++ b/pbp/file_helper.py
@@ -98,7 +98,11 @@ class SoundStatus:
             sound_filename = f"{self.audio_base_dir}/{path}"
         else:
             sound_filename = path
-        return sound_filename
+
+        if os.name == 'nt':
+            return self.parsed_uri.netloc+self.parsed_uri.path
+        else:
+            return sound_filename
 
     def remove_downloaded_file(self):
         if not pathlib.Path(self.sound_filename).exists():
@@ -352,7 +356,10 @@ class FileHelper:
         if parsed_uri.scheme == "s3":
             return self._get_json_s3(parsed_uri)
         #  simply assume local file:
-        return self._get_json_local(parsed_uri.path)
+        if os.name == 'nt':
+            return self._get_json_local(uri)
+        else:
+            return self._get_json_local(parsed_uri.path)
 
     def _get_json_s3(self, parsed_uri: ParseResult) -> Optional[str]:
         local_filename = _download(


### PR DESCRIPTION
This commit introduces proper path construction to support non-local file access on Windows. While path processing works as expected, there are known issues in the logs where paths may be incorrectly represented with both forward and backslashes. These erroneous paths are not processed, but they do appear in the logs.

The changes were made to ensure correct path building without deviating from the provided class objects. A future feature request should address improving log accuracy for Windows environments.